### PR TITLE
Add Discover tab and centralize realtime Firestore data handling

### DIFF
--- a/App.js
+++ b/App.js
@@ -45,13 +45,17 @@ const App = () => {
     <UserProvider>
       <GpsProvider>
         <NavigationContainer>
-          <Stack.Navigator initialRouteName="Intro">
+          <Stack.Navigator initialRouteName={showIntro ? 'Intro' : user ? 'MainApp' : 'Login'}>
             {showIntro ? (
               <Stack.Screen name="Intro" component={IntroScreen} options={{ headerShown: false }} />
             ) : (
               <>
-                <Stack.Screen name="Login" component={LoginScreen} options={{ headerShown: false }} />
-                <Stack.Screen name="Register" component={RegisterScreen} options={{ headerShown: false }} />
+                {!user && (
+                  <>
+                    <Stack.Screen name="Login" component={LoginScreen} options={{ headerShown: false }} />
+                    <Stack.Screen name="Register" component={RegisterScreen} options={{ headerShown: false }} />
+                  </>
+                )}
                 <Stack.Screen name="MainApp" component={TabNavigator} options={{ headerShown: false }} />
                 <Stack.Screen name="ProductDetails" component={ProductDetailsScreen} />
                 <Stack.Screen name="Upload" component={UploadScreen} />

--- a/components/EventCard.js
+++ b/components/EventCard.js
@@ -1,0 +1,80 @@
+import React from 'react';
+import { Image, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+
+const EventCard = ({ event, onPress }) => {
+  if (!event) {
+    return null;
+  }
+
+  const title = event.eventname || event.title || 'Unnamed event';
+  const description = event.eventDescription || event.description || '';
+  const category = event.category || event.eventType || null;
+  const date = event.date || event.startDate || null;
+
+  return (
+    <TouchableOpacity style={styles.card} onPress={() => onPress?.(event)}>
+      {event.image ? (
+        <Image source={{ uri: event.image }} style={styles.image} />
+      ) : (
+        <View style={[styles.image, styles.placeholder]}>
+          <Text style={styles.placeholderText}>No image</Text>
+        </View>
+      )}
+      <View style={styles.textContainer}>
+        <Text style={styles.title}>{title}</Text>
+        {category ? <Text style={styles.category}>{category}</Text> : null}
+        {date ? <Text style={styles.date}>{String(date)}</Text> : null}
+        {description ? <Text style={styles.description} numberOfLines={2}>{description}</Text> : null}
+      </View>
+    </TouchableOpacity>
+  );
+};
+
+const styles = StyleSheet.create({
+  card: {
+    backgroundColor: '#2a2a2a',
+    borderRadius: 14,
+    overflow: 'hidden',
+    marginVertical: 8,
+  },
+  image: {
+    width: '100%',
+    height: 180,
+    backgroundColor: '#1c1c1c',
+  },
+  placeholder: {
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  placeholderText: {
+    color: '#777',
+    fontSize: 12,
+  },
+  textContainer: {
+    padding: 16,
+  },
+  title: {
+    fontSize: 18,
+    color: '#fff',
+    fontWeight: 'bold',
+  },
+  category: {
+    marginTop: 4,
+    color: '#FF5C93',
+    textTransform: 'uppercase',
+    fontSize: 12,
+    letterSpacing: 1,
+  },
+  date: {
+    marginTop: 4,
+    color: '#ccc',
+    fontSize: 12,
+  },
+  description: {
+    marginTop: 8,
+    color: '#ddd',
+    fontSize: 14,
+  },
+});
+
+export default EventCard;

--- a/components/ProductCard.js
+++ b/components/ProductCard.js
@@ -1,0 +1,111 @@
+import React from 'react';
+import { Image, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+
+const ProductCard = ({
+  product,
+  onBuyPress,
+  onDetailsPress,
+  disabled = false,
+}) => {
+  if (!product) {
+    return null;
+  }
+
+  return (
+    <View style={styles.card}>
+      {product.image ? (
+        <Image source={{ uri: product.image }} style={styles.image} />
+      ) : (
+        <View style={[styles.image, styles.placeholder]}>
+          <Text style={styles.placeholderText}>No image</Text>
+        </View>
+      )}
+      <Text style={styles.title}>{product.name}</Text>
+      <Text style={styles.price}>{product.price ?? 0}</Text>
+      {product.description ? (
+        <Text style={styles.description}>{product.description}</Text>
+      ) : null}
+      <TouchableOpacity
+        style={[styles.actionButton, disabled && styles.actionButtonDisabled]}
+        onPress={() => onBuyPress?.(product)}
+        disabled={disabled}
+      >
+        <Text style={styles.actionButtonText}>
+          {disabled ? 'Processing…' : 'Buy'}
+        </Text>
+      </TouchableOpacity>
+      <TouchableOpacity style={styles.secondaryButton} onPress={() => onDetailsPress?.(product)}>
+        <Text style={styles.secondaryButtonText}>View details</Text>
+      </TouchableOpacity>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  card: {
+    padding: 20,
+    marginVertical: 10,
+    borderRadius: 12,
+    backgroundColor: '#333',
+  },
+  image: {
+    width: '100%',
+    height: 180,
+    borderRadius: 10,
+    marginBottom: 15,
+    backgroundColor: '#222',
+  },
+  placeholder: {
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  placeholderText: {
+    color: '#777',
+    fontSize: 12,
+  },
+  title: {
+    fontSize: 22,
+    fontWeight: 'bold',
+    color: '#fff',
+  },
+  price: {
+    fontSize: 18,
+    color: '#FF5C93',
+    marginVertical: 10,
+  },
+  description: {
+    fontSize: 14,
+    color: '#aaa',
+    marginBottom: 15,
+  },
+  actionButton: {
+    backgroundColor: '#FF5C93',
+    borderRadius: 8,
+    paddingVertical: 12,
+    alignItems: 'center',
+  },
+  actionButtonDisabled: {
+    opacity: 0.6,
+  },
+  actionButtonText: {
+    color: '#fff',
+    fontSize: 16,
+    fontWeight: 'bold',
+  },
+  secondaryButton: {
+    marginTop: 10,
+    borderRadius: 8,
+    paddingVertical: 12,
+    alignItems: 'center',
+    borderColor: '#FF5C93',
+    borderWidth: 1,
+  },
+  secondaryButtonText: {
+    color: '#FF5C93',
+    fontSize: 16,
+    fontWeight: 'bold',
+    textTransform: 'uppercase',
+  },
+});
+
+export default ProductCard;

--- a/hooks/useFirestoreCollection.js
+++ b/hooks/useFirestoreCollection.js
@@ -1,0 +1,98 @@
+import { useEffect, useMemo, useState } from 'react';
+import { collection, doc, onSnapshot, orderBy as orderByClause, query, where as whereClause } from 'firebase/firestore';
+import { db } from '../components/firebase';
+
+const buildQuery = (collectionRef, { where = [], orderBy } = {}) => {
+  let firestoreQuery = collectionRef;
+
+  where.forEach(([field, operator, value]) => {
+    firestoreQuery = query(firestoreQuery, whereClause(field, operator, value));
+  });
+
+  if (orderBy?.field) {
+    firestoreQuery = query(
+      firestoreQuery,
+      orderByClause(orderBy.field, orderBy.direction ?? 'asc')
+    );
+  }
+
+  return firestoreQuery;
+};
+
+const normaliseWhere = (clauses = []) =>
+  clauses.map(([field, operator, value]) => [field, operator, value]);
+
+export const useFirestoreCollection = (path, options = {}) => {
+  const [data, setData] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  const memoisedOptions = useMemo(
+    () => ({
+      where: normaliseWhere(options.where),
+      orderBy: options.orderBy ?? null,
+    }),
+    [JSON.stringify(options.where ?? []), options.orderBy?.field, options.orderBy?.direction]
+  );
+
+  useEffect(() => {
+    if (!path) {
+      setData([]);
+      setLoading(false);
+      return undefined;
+    }
+
+    const collectionRef = collection(db, path);
+    const firestoreQuery = buildQuery(collectionRef, memoisedOptions);
+
+    setLoading(true);
+    const unsubscribe = onSnapshot(
+      firestoreQuery,
+      (snapshot) => {
+        const nextData = snapshot.docs.map((snapshotDoc) => ({ id: snapshotDoc.id, ...snapshotDoc.data() }));
+        setData(nextData);
+        setLoading(false);
+      },
+      (snapshotError) => {
+        console.error(`Failed to subscribe to collection "${path}":`, snapshotError);
+        setError(snapshotError);
+        setLoading(false);
+      }
+    );
+
+    return () => unsubscribe();
+  }, [path, memoisedOptions]);
+
+  return { data, loading, error };
+};
+
+export const useFirestoreDocument = (path) => {
+  const [data, setData] = useState(null);
+  const [loading, setLoading] = useState(Boolean(path));
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    if (!path) {
+      setData(null);
+      setLoading(false);
+      return undefined;
+    }
+
+    const unsubscribe = onSnapshot(
+      doc(db, path),
+      (snapshot) => {
+        setData(snapshot.exists() ? { id: snapshot.id, ...snapshot.data() } : null);
+        setLoading(false);
+      },
+      (snapshotError) => {
+        console.error(`Failed to subscribe to document "${path}":`, snapshotError);
+        setError(snapshotError);
+        setLoading(false);
+      }
+    );
+
+    return () => unsubscribe();
+  }, [path]);
+
+  return { data, loading, error };
+};

--- a/navigation/TabNavigator.js
+++ b/navigation/TabNavigator.js
@@ -1,12 +1,13 @@
 import React from 'react';
 import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
 import Icon from 'react-native-vector-icons/Ionicons';
+import DiscoverScreen from '../screens/DiscoverScreen';
 import MapViewScreen from '../screens/MapViewScreen';
 import ChatListScreen from '../screens/ChatListScreen';
 import EventShopScreen from '../screens/EventShopScreen';
 import PostScreen from '../screens/PostScreen';
-import ProfileScreen from '../screens/ProfileScreen'; // Import ProfileScreen
-import { useUser } from '../UserContext'; // Import useUser hook
+import ProfileScreen from '../screens/ProfileScreen';
+import { useUser } from '../UserContext';
 
 const Tab = createBottomTabNavigator();
 
@@ -15,11 +16,15 @@ const TabNavigator = () => {
 
   return (
     <Tab.Navigator
+      initialRouteName="Discover"
       screenOptions={({ route }) => ({
         tabBarIcon: ({ focused, color, size }) => {
           let iconName;
 
           switch (route.name) {
+            case 'Discover':
+              iconName = focused ? 'planet' : 'planet-outline';
+              break;
             case 'MapView':
               iconName = focused ? 'map' : 'map-outline';
               break;
@@ -47,6 +52,7 @@ const TabNavigator = () => {
         },
       })}
     >
+      <Tab.Screen name="Discover" component={DiscoverScreen} options={{ headerShown: false }} />
       <Tab.Screen name="MapView" component={MapViewScreen} options={{ headerShown: false }} />
       <Tab.Screen name="ChatList" component={ChatListScreen} />
       <Tab.Screen name="EventShop" component={EventShopScreen} />

--- a/screens/ChatComponent.js
+++ b/screens/ChatComponent.js
@@ -1,9 +1,8 @@
 import React, { useState, useEffect } from 'react';
 import { View, StyleSheet, TouchableOpacity, Text, Platform, KeyboardAvoidingView, Keyboard } from 'react-native';
 import { GiftedChat, Bubble, InputToolbar, Composer, Send } from 'react-native-gifted-chat';
-import { getFirestore, collection, addDoc, query, onSnapshot, orderBy, where, doc, getDoc } from 'firebase/firestore';
-import { getAuth } from 'firebase/auth';
-import app from '../components/firebase';
+import { collection, addDoc, query, onSnapshot, orderBy, where, doc, getDoc } from 'firebase/firestore';
+import { auth, db } from '../components/firebase';
 import { useNavigation, useRoute } from '@react-navigation/native';
 
 const styles = StyleSheet.create({
@@ -33,7 +32,6 @@ const styles = StyleSheet.create({
 const ChatComponent = () => {
   const [messages, setMessages] = useState([]);
   const [username, setUsername] = useState('');
-  const auth = getAuth(app);
   const user = auth.currentUser;
   const navigation = useNavigation();
   const route = useRoute();
@@ -54,7 +52,7 @@ const ChatComponent = () => {
       const fetchMessages = async () => {
         if (user && selectedUser) {
           const q = query(
-            collection(getFirestore(app), 'messages'),
+            collection(db, 'messages'),
             orderBy('createdAt', 'desc'),
             where('user._id', 'in', [user.uid, selectedUser.uid]),
             where('receiver._id', 'in', [user.uid, selectedUser.uid])
@@ -91,7 +89,6 @@ const ChatComponent = () => {
   const handleSend = async (newMessages = []) => {
     if (user && selectedUser) {
       const text = newMessages[0].text;
-      const db = getFirestore(app);
       const docRef = doc(db, 'users', user.uid);
       getDoc(docRef)
         .then((docSnap) => {

--- a/screens/ChatListScreen.js
+++ b/screens/ChatListScreen.js
@@ -1,8 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
-import { getFirestore, collection, query, onSnapshot, where, orderBy, getDocs } from 'firebase/firestore';
-import { getAuth } from 'firebase/auth';
-import app from '../components/firebase';
+import { collection, query, onSnapshot, where, orderBy, getDocs } from 'firebase/firestore';
+import { auth, db } from '../components/firebase';
 import { useNavigation } from '@react-navigation/native';
 
 const styles = StyleSheet.create({
@@ -38,9 +37,21 @@ const styles = StyleSheet.create({
   },
 });
 
+const formatDate = (isoString) => {
+  if (!isoString) {
+    return '';
+  }
+
+  try {
+    const date = new Date(isoString);
+    return `${date.toLocaleDateString()} ${date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}`;
+  } catch (error) {
+    return isoString;
+  }
+};
+
 const ChatListScreen = ({ navigation }) => {
   const [chats, setChats] = useState([]);
-  const auth = getAuth(app);
   const user = auth.currentUser;
 
   useEffect(() => {
@@ -54,7 +65,6 @@ const ChatListScreen = ({ navigation }) => {
     });
 
     if (user) {
-      const db = getFirestore(app);
       const q = query(
         collection(db, 'messages'),
         where('user._id', '==', user.uid),
@@ -111,7 +121,7 @@ const ChatListScreen = ({ navigation }) => {
   };
 
   const getUserIdByUsername = async (username) => {
-    const usersCollection = collection(getFirestore(app), 'users');
+    const usersCollection = collection(db, 'users');
     const userQuery = query(usersCollection, where('username', '==', username));
     const userSnapshot = await getDocs(userQuery);
     return userSnapshot.docs.length > 0 ? userSnapshot.docs[0].data().uid : null;
@@ -130,7 +140,7 @@ const ChatListScreen = ({ navigation }) => {
           >
             <Text style={styles.chatName}>{chat.name}</Text>
             <Text style={styles.chatMessage}>{chat.lastMessage}</Text>
-            <Text style={styles.chatDate}>{chat.createdAt}</Text>
+            <Text style={styles.chatDate}>{formatDate(chat.createdAt)}</Text>
           </TouchableOpacity>
         ))
       )}

--- a/screens/DiscoverScreen.js
+++ b/screens/DiscoverScreen.js
@@ -1,0 +1,290 @@
+import React, { useMemo, useState } from 'react';
+import {
+  ActivityIndicator,
+  FlatList,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TextInput,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+import { useNavigation } from '@react-navigation/native';
+import EventCard from '../components/EventCard';
+import { useFirestoreCollection } from '../hooks/useFirestoreCollection';
+
+const ACCENT = '#FF5C93';
+const BACKGROUND = '#1c1c1c';
+
+const DiscoverScreen = () => {
+  const navigation = useNavigation();
+  const [searchQuery, setSearchQuery] = useState('');
+  const [selectedCategory, setSelectedCategory] = useState('all');
+
+  const { data: events, loading: eventsLoading } = useFirestoreCollection('events', {
+    orderBy: { field: 'createdAt', direction: 'desc' },
+  });
+  const { data: posts, loading: postsLoading } = useFirestoreCollection('posts', {
+    orderBy: { field: 'createdAt', direction: 'desc' },
+  });
+
+  const categories = useMemo(() => {
+    const unique = new Set();
+    events.forEach((event) => {
+      if (event?.category) {
+        unique.add(event.category);
+      } else if (event?.eventType) {
+        unique.add(event.eventType);
+      }
+    });
+    return ['all', ...Array.from(unique)];
+  }, [events]);
+
+  const filteredEvents = useMemo(() => {
+    const queryLower = searchQuery.trim().toLowerCase();
+
+    return events.filter((event) => {
+      const category = (event.category || event.eventType || '').toLowerCase();
+      const matchesCategory = selectedCategory === 'all' || category === selectedCategory.toLowerCase();
+
+      if (!matchesCategory) {
+        return false;
+      }
+
+      if (!queryLower) {
+        return true;
+      }
+
+      const target = [
+        event.eventname,
+        event.title,
+        event.eventDescription,
+        event.description,
+      ]
+        .filter(Boolean)
+        .join(' ') // combine text fields
+        .toLowerCase();
+
+      return target.includes(queryLower);
+    });
+  }, [events, searchQuery, selectedCategory]);
+
+  const trendingPosts = useMemo(() => {
+    return [...posts]
+      .sort((a, b) => (b.likes ?? 0) - (a.likes ?? 0))
+      .slice(0, 3);
+  }, [posts]);
+
+  const handleEventPress = (event) => {
+    navigation.navigate('MapView', { highlightEventId: event.id });
+  };
+
+  const renderCategory = (category) => {
+    const isActive = selectedCategory === category;
+    return (
+      <TouchableOpacity
+        key={category}
+        style={[styles.categoryChip, isActive && styles.categoryChipActive]}
+        onPress={() => setSelectedCategory(category)}
+      >
+        <Text style={[styles.categoryChipText, isActive && styles.categoryChipTextActive]}>
+          {category.toUpperCase()}
+        </Text>
+      </TouchableOpacity>
+    );
+  };
+
+  return (
+    <ScrollView style={styles.container} contentContainerStyle={styles.content}>
+      <Text style={styles.heading}>Entdecke neue Events</Text>
+      <Text style={styles.subheading}>
+        Finde angesagte Veranstaltungen und sieh, was deine Community teilt.
+      </Text>
+
+      <TextInput
+        placeholder="Suche nach Events oder Schlagwörtern"
+        placeholderTextColor="#888"
+        style={styles.searchInput}
+        value={searchQuery}
+        onChangeText={setSearchQuery}
+      />
+
+      <ScrollView
+        horizontal
+        showsHorizontalScrollIndicator={false}
+        style={styles.categoryContainer}
+        contentContainerStyle={styles.categoryContent}
+      >
+        {categories.map(renderCategory)}
+      </ScrollView>
+
+      {eventsLoading ? (
+        <ActivityIndicator style={styles.loader} color={ACCENT} />
+      ) : (
+        <FlatList
+          data={filteredEvents}
+          keyExtractor={(item) => item.id}
+          renderItem={({ item }) => <EventCard event={item} onPress={handleEventPress} />}
+          ListEmptyComponent={
+            <View style={styles.emptyState}>
+              <Text style={styles.emptyStateTitle}>Keine passenden Events gefunden</Text>
+              <Text style={styles.emptyStateDescription}>
+                Passe deine Filter an oder lade neue Erlebnisse hoch!
+              </Text>
+            </View>
+          }
+          scrollEnabled={false}
+        />
+      )}
+
+      <View style={styles.sectionHeader}>
+        <Text style={styles.sectionTitle}>Trending Posts</Text>
+        <TouchableOpacity onPress={() => navigation.navigate('Post')}>
+          <Text style={styles.sectionLink}>Alle anzeigen</Text>
+        </TouchableOpacity>
+      </View>
+
+      {postsLoading ? (
+        <ActivityIndicator style={styles.loader} color={ACCENT} />
+      ) : (
+        <View style={styles.trendingList}>
+          {trendingPosts.map((post) => (
+            <TouchableOpacity
+              key={post.id}
+              style={styles.trendingCard}
+              onPress={() => navigation.navigate('Post')}
+            >
+              <Text style={styles.trendingTitle}>{post.title || 'Untitled Post'}</Text>
+              <Text style={styles.trendingMeta} numberOfLines={1}>
+                {post.user?.username ? `von ${post.user.username}` : 'Unbekannt'}
+              </Text>
+              <Text style={styles.trendingDescription} numberOfLines={2}>
+                {post.description || post.text || 'Keine Beschreibung vorhanden.'}
+              </Text>
+              <Text style={styles.trendingLikes}>{`${post.likes ?? 0} Likes`}</Text>
+            </TouchableOpacity>
+          ))}
+          {trendingPosts.length === 0 ? (
+            <Text style={styles.emptyStateDescription}>
+              Es gibt noch keine Beiträge. Teile als Erste*r deine Highlights!
+            </Text>
+          ) : null}
+        </View>
+      )}
+    </ScrollView>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: BACKGROUND,
+  },
+  content: {
+    padding: 16,
+    paddingBottom: 32,
+  },
+  heading: {
+    fontSize: 28,
+    fontWeight: 'bold',
+    color: '#fff',
+  },
+  subheading: {
+    color: '#ccc',
+    marginTop: 4,
+  },
+  searchInput: {
+    marginTop: 20,
+    backgroundColor: '#2a2a2a',
+    borderRadius: 12,
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+    color: '#fff',
+  },
+  categoryContainer: {
+    marginTop: 16,
+  },
+  categoryContent: {
+    paddingVertical: 4,
+  },
+  categoryChip: {
+    paddingHorizontal: 14,
+    paddingVertical: 8,
+    borderRadius: 20,
+    backgroundColor: '#2a2a2a',
+    marginRight: 10,
+  },
+  categoryChipActive: {
+    backgroundColor: ACCENT,
+  },
+  categoryChipText: {
+    color: '#bbb',
+    fontWeight: '500',
+    fontSize: 12,
+  },
+  categoryChipTextActive: {
+    color: '#fff',
+  },
+  loader: {
+    marginVertical: 20,
+  },
+  emptyState: {
+    paddingVertical: 40,
+    alignItems: 'center',
+  },
+  emptyStateTitle: {
+    color: '#fff',
+    fontWeight: 'bold',
+    fontSize: 18,
+  },
+  emptyStateDescription: {
+    color: '#aaa',
+    marginTop: 8,
+    textAlign: 'center',
+  },
+  sectionHeader: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginTop: 32,
+  },
+  sectionTitle: {
+    color: '#fff',
+    fontSize: 20,
+    fontWeight: 'bold',
+  },
+  sectionLink: {
+    color: ACCENT,
+    fontWeight: '600',
+  },
+  trendingList: {
+    marginTop: 16,
+  },
+  trendingCard: {
+    backgroundColor: '#2a2a2a',
+    borderRadius: 12,
+    padding: 16,
+    marginBottom: 12,
+  },
+  trendingTitle: {
+    color: '#fff',
+    fontWeight: 'bold',
+    fontSize: 16,
+  },
+  trendingMeta: {
+    color: '#ccc',
+    marginTop: 4,
+  },
+  trendingDescription: {
+    color: '#ddd',
+    marginTop: 8,
+    fontSize: 14,
+  },
+  trendingLikes: {
+    marginTop: 12,
+    color: ACCENT,
+    fontWeight: '600',
+  },
+});
+
+export default DiscoverScreen;

--- a/screens/EventShopScreen.js
+++ b/screens/EventShopScreen.js
@@ -1,51 +1,18 @@
-import React, { useState, useEffect, useRef } from 'react';
-import { View, Text, Image, StyleSheet, FlatList, TouchableOpacity, Alert } from 'react-native';
-import { useNavigation } from '@react-navigation/native';
-import { getAuth } from 'firebase/auth';
-import { getFirestore, doc, getDoc, updateDoc, collection, query, onSnapshot } from 'firebase/firestore';
-import { useUser } from '../UserContext';
-import app from '../components/firebase';
+import React, { useEffect, useMemo, useState } from 'react';
+import { ActivityIndicator, Alert, FlatList, StyleSheet, Text, View } from 'react-native';
+import { doc, getDoc, onSnapshot, updateDoc } from 'firebase/firestore';
+import ProductCard from '../components/ProductCard';
+import { auth, db } from '../components/firebase';
+import { useFirestoreCollection } from '../hooks/useFirestoreCollection';
 
 const EventShopScreen = ({ navigation }) => {
-  const [socket, setSocket] = useState(null);
-  const [username, setUsername] = useState('');
-  const [latitude, setLatitude] = useState('');
-  const [longitude, setLongitude] = useState('');
-  const [userLocations, setUserLocations] = useState([]);
   const [balance, setBalance] = useState(0);
-  const [products, setProducts] = useState([]);
-  const eventUsernameRef = useRef('');
-  const { user: contextUser } = useUser();
-  const auth = getAuth(app);
-  const db = getFirestore(app);
+  const [processingProductId, setProcessingProductId] = useState(null);
   const user = auth.currentUser;
 
+  const { data: products, loading: loadingProducts } = useFirestoreCollection('products');
+
   useEffect(() => {
-    const fetchBalance = async () => {
-      if (user) {
-        const userRef = doc(db, 'users', user.uid);
-        const userDoc = await getDoc(userRef);
-        if (userDoc.exists()) {
-          setBalance(userDoc.data().balance);
-        }
-      }
-    };
-
-    const fetchProducts = () => {
-      const q = query(collection(db, 'products'));
-      const unsubscribe = onSnapshot(q, (querySnapshot) => {
-        const productsData = [];
-        querySnapshot.forEach((doc) => {
-          productsData.push({ id: doc.id, ...doc.data() });
-        });
-        setProducts(productsData);
-      });
-      return unsubscribe;
-    };
-
-    fetchBalance();
-    const unsubscribeProducts = fetchProducts();
-
     navigation.setOptions({
       title: 'Event Shop',
       headerStyle: {
@@ -56,63 +23,87 @@ const EventShopScreen = ({ navigation }) => {
         fontWeight: 'bold',
       },
     });
+  }, [navigation]);
 
-    return () => {
-      unsubscribeProducts();
-    };
-  }, [navigation, user]);
+  useEffect(() => {
+    if (!user?.uid) {
+      setBalance(0);
+      return undefined;
+    }
+
+    const unsubscribe = onSnapshot(doc(db, 'users', user.uid), (snapshot) => {
+      setBalance(snapshot.exists() ? snapshot.data().balance ?? 0 : 0);
+    });
+
+    return () => unsubscribe();
+  }, [user?.uid]);
+
+  const sortedProducts = useMemo(
+    () => [...products].sort((a, b) => (a.price ?? 0) - (b.price ?? 0)),
+    [products]
+  );
 
   const handleProductPress = async (product) => {
-    if (!user) {
-      Alert.alert('Error', 'You must be logged in to make a purchase.');
+    if (!user?.uid) {
+      Alert.alert('Fehler', 'Bitte melde dich an, um Produkte zu kaufen.');
       return;
     }
 
-    const userRef = doc(db, 'users', user.uid);
-    const userDoc = await getDoc(userRef);
+    setProcessingProductId(product.id);
+    try {
+      const userRef = doc(db, 'users', user.uid);
+      const userDoc = await getDoc(userRef);
 
-    if (userDoc.exists()) {
-      const userData = userDoc.data();
-      if (userData.balance >= product.price) {
-        const newBalance = userData.balance - product.price;
-        await updateDoc(userRef, { balance: newBalance });
-        Alert.alert('Success', `You have successfully purchased ${product.name}.`);
-        // Here you would typically add the purchased item to the user's inventory
-      } else {
-        Alert.alert('Error', 'You do not have enough balance to make this purchase.');
+      if (!userDoc.exists()) {
+        Alert.alert('Fehler', 'Benutzerkonto nicht gefunden.');
+        return;
       }
-    } else {
-      Alert.alert('Error', 'Could not find user data.');
+
+      const currentBalance = userDoc.data().balance ?? 0;
+      if (currentBalance < (product.price ?? 0)) {
+        Alert.alert('Fehler', 'Dein Kontostand reicht nicht aus.');
+        return;
+      }
+
+      const newBalance = currentBalance - (product.price ?? 0);
+      await updateDoc(userRef, { balance: newBalance });
+      Alert.alert('Erfolg', `Du hast ${product.name} gekauft.`);
+    } catch (error) {
+      console.error('Purchase failed:', error);
+      Alert.alert('Fehler', 'Beim Kauf ist etwas schiefgelaufen.');
+    } finally {
+      setProcessingProductId(null);
     }
   };
 
   return (
     <View style={styles.container}>
-      <Text style={styles.balanceText}>Balance: {balance}</Text>
-      <FlatList
-        data={products}
-        keyExtractor={(item) => item.id}
-        renderItem={({ item }) => (
-          <View style={styles.itemContainer}>
-            <View style={styles.imageContainer}>
-              <Image source={{ uri: item.image }} style={styles.itemImage} />
+      <Text style={styles.balanceText}>Kontostand: {balance}</Text>
+      {loadingProducts ? (
+        <ActivityIndicator style={styles.loader} color="#FF5C93" />
+      ) : (
+        <FlatList
+          data={sortedProducts}
+          keyExtractor={(item) => item.id}
+          renderItem={({ item }) => (
+            <ProductCard
+              product={item}
+              onBuyPress={handleProductPress}
+              onDetailsPress={(product) => navigation.navigate('ProductDetails', { product })}
+              disabled={processingProductId === item.id}
+            />
+          )}
+          contentContainerStyle={styles.listContent}
+          ListEmptyComponent={
+            <View style={styles.emptyState}>
+              <Text style={styles.emptyStateTitle}>Noch keine Produkte</Text>
+              <Text style={styles.emptyStateDescription}>
+                Schau später wieder vorbei oder füge neue Produkte im Admin-Bereich hinzu.
+              </Text>
             </View>
-            <Text style={styles.itemName}>{item.name}</Text>
-            <View style={styles.priceContainer}>
-              <Text style={styles.itemPrice}>{item.price}</Text>
-            </View>
-            <View style={styles.descriptionContainer}>
-              <Text style={styles.itemDescription}>{item.description}</Text>
-            </View>
-            <TouchableOpacity style={styles.buyButton} onPress={() => handleProductPress(item)}>
-              <Text style={styles.buyButtonText}>BUY</Text>
-            </TouchableOpacity>
-            <TouchableOpacity style={styles.detailsButton} onPress={() => navigation.navigate('ProductDetails', { product: item })}>
-              <Text style={styles.detailsButtonText}>View Details</Text>
-            </TouchableOpacity>
-          </View>
-        )}
-      />
+          }
+        />
+      )}
     </View>
   );
 };
@@ -128,59 +119,28 @@ const styles = StyleSheet.create({
     fontWeight: 'bold',
     color: '#FF5C93',
     textAlign: 'center',
-    marginBottom: 20,
+    marginBottom: 12,
   },
-  itemContainer: {
-    padding: 20,
-    marginVertical: 10,
-    borderRadius: 10,
-    backgroundColor: '#333',
+  listContent: {
+    paddingBottom: 24,
   },
-  itemImage: {
-    width: '100%',
-    height: 180,
-    borderRadius: 10,
-    marginBottom: 15,
+  loader: {
+    marginTop: 40,
   },
-  itemName: {
-    fontSize: 22,
-    fontWeight: 'bold',
+  emptyState: {
+    marginTop: 80,
+    alignItems: 'center',
+    paddingHorizontal: 16,
+  },
+  emptyStateTitle: {
     color: '#fff',
-  },
-  itemPrice: {
     fontSize: 18,
-    color: '#FF5C93',
-    marginVertical: 10,
+    fontWeight: 'bold',
   },
-  itemDescription: {
-    fontSize: 14,
+  emptyStateDescription: {
     color: '#aaa',
-    marginBottom: 15,
-  },
-  buyButton: {
-    backgroundColor: '#FF5C93',
-    borderRadius: 8,
-    paddingVertical: 12,
-    alignItems: 'center',
-  },
-  buyButtonText: {
-    color: '#fff',
-    fontSize: 16,
-    fontWeight: 'bold',
-  },
-  detailsButton: {
-    marginTop: 10,
-    backgroundColor: 'transparent',
-    borderRadius: 8,
-    paddingVertical: 12,
-    alignItems: 'center',
-    borderColor: '#FF5C93',
-    borderWidth: 1,
-  },
-  detailsButtonText: {
-    color: '#FF5C93',
-    fontSize: 16,
-    fontWeight: 'bold',
+    marginTop: 8,
+    textAlign: 'center',
   },
 });
 

--- a/screens/MapViewScreen.js
+++ b/screens/MapViewScreen.js
@@ -1,43 +1,61 @@
-import React, { useState, useEffect, useRef } from 'react';
-import { View, StyleSheet, ActivityIndicator, Image, Text, Switch } from 'react-native';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import { Alert, Image, StyleSheet, Switch, Text, View } from 'react-native';
 import MapView, { Marker } from 'react-native-maps';
 import * as Location from 'expo-location';
-import { getFirestore, query, where, getDocs, collection, doc, setDoc, onSnapshot, deleteDoc } from 'firebase/firestore';
+import { getFirestore, query, where, getDocs, collection, doc, setDoc, deleteDoc } from 'firebase/firestore';
 import { app, db } from '../components/firebase';
 import { useUser } from '../UserContext';
+import { useFirestoreCollection } from '../hooks/useFirestoreCollection';
 
-const MapViewScreen = ({ navigation }) => {
+const MapViewScreen = ({ navigation, route }) => {
   const { user } = useUser();
   const username = user ? user.username : '';
 
-  const [userLocations, setUserLocations] = useState([]);
-  const [eventLocations, setEventLocations] = useState([]);
   const [myLocation, setMyLocation] = useState(null);
   const [mapReady, setMapReady] = useState(false);
   const [gpsEnabled, setGpsEnabled] = useState(true);
   const [initialRegionSet, setInitialRegionSet] = useState(false);
   const [region, setRegion] = useState(null);
-  const [loading, setLoading] = useState(false);
   const locationSubscription = useRef(null);
+  const highlightEventId = route?.params?.highlightEventId;
+
+  const { data: userLocations } = useFirestoreCollection('locations');
+  const { data: eventLocations } = useFirestoreCollection('events');
+
+  const defaultRegion = useMemo(
+    () => ({
+      latitude: 52.52,
+      longitude: 13.405,
+      latitudeDelta: 0.5,
+      longitudeDelta: 0.5,
+    }),
+    []
+  );
+  const activeUsers = useMemo(
+    () => userLocations.filter((location) => location.gpsEnabled !== false),
+    [userLocations]
+  );
+  const eventCount = eventLocations.length;
 
   useEffect(() => {
-    const locationsCollection = collection(db, 'locations');
-    const unsubscribeLocations = onSnapshot(locationsCollection, (snapshot) => {
-      const locations = snapshot.docs.map(doc => doc.data());
-      setUserLocations(locations);
-    });
+    if (!highlightEventId) {
+      return;
+    }
 
-    const eventsCollection = collection(db, 'events');
-    const unsubscribeEvents = onSnapshot(eventsCollection, (snapshot) => {
-      const events = snapshot.docs.map(doc => doc.data());
-      setEventLocations(events);
-    });
-
-    return () => {
-      unsubscribeLocations();
-      unsubscribeEvents();
-    };
-  }, []);
+    const eventToHighlight = eventLocations.find((event) => event.id === highlightEventId);
+    if (eventToHighlight?.latitude && eventToHighlight?.longitude) {
+      setRegion({
+        latitude: eventToHighlight.latitude,
+        longitude: eventToHighlight.longitude,
+        latitudeDelta: 0.02,
+        longitudeDelta: 0.02,
+      });
+      setInitialRegionSet(true);
+      setMapReady(true);
+      navigation.setParams?.({ highlightEventId: undefined });
+      Alert.alert(eventToHighlight.eventname || 'Event', eventToHighlight.eventDescription || '');
+    }
+  }, [highlightEventId, eventLocations, navigation]);
 
   const watchLocation = async () => {
     let { status } = await Location.requestForegroundPermissionsAsync();
@@ -103,7 +121,7 @@ const MapViewScreen = ({ navigation }) => {
   }, [username, gpsEnabled]);
 
   const handleMarkerPressEvent = (event) => {
-    alert(event.eventDescription);
+    Alert.alert(event.eventname || 'Event', event.eventDescription || '');
   };
 
   const handleMarkerPress = async (user) => {
@@ -111,7 +129,6 @@ const MapViewScreen = ({ navigation }) => {
       const userId = await getUserIdByUsername(user.username);
       if (userId) {
         const userWithUid = { ...user, uid: userId };
-        console.log('Navigating with selectedUser:', userWithUid);
         navigation.navigate('Chat', { selectedUser: userWithUid });
       } else {
         console.warn('Benutzer nicht gefunden.');
@@ -141,66 +158,82 @@ const MapViewScreen = ({ navigation }) => {
     }
   }, [initialRegionSet, myLocation]);
 
+  const mapRegion = region ??
+    (myLocation
+      ? {
+          latitude: myLocation.latitude,
+          longitude: myLocation.longitude,
+          latitudeDelta: 0.02,
+          longitudeDelta: 0.02,
+        }
+      : defaultRegion);
+
   return (
-    <View style={{ flex: 1 }}>
-      {loading ? (
-        <ActivityIndicator />
-      ) : (
-        <>
-          <MapView
-            style={{ flex: 1 }}
-            initialRegion={region}
-            onLayout={() => {
-              setMapReady(true);
-              if (myLocation) {
-                setInitialRegionSet(true);
-              }
-            }}
+    <View style={styles.container}>
+      <MapView
+        style={styles.map}
+        initialRegion={mapRegion}
+        region={region ?? undefined}
+        onLayout={() => {
+          setMapReady(true);
+          if (myLocation) {
+            setInitialRegionSet(true);
+          }
+        }}
+      >
+        {mapReady &&
+          eventLocations.map((event) => (
+            <Marker
+              key={event.id ?? `${event.latitude}-${event.longitude}`}
+              coordinate={{ latitude: event.latitude, longitude: event.longitude }}
+              onPress={() => handleMarkerPressEvent(event)}
+            >
+              <View style={styles.markerContainer}>
+                <Text style={styles.markerText}>{event.eventname}</Text>
+                {event.image ? <Image source={{ uri: event.image }} style={styles.markerImage} /> : null}
+              </View>
+            </Marker>
+          ))}
+        {mapReady &&
+          userLocations.map((user) => (
+            <Marker
+              key={user.username ?? `${user.latitude}-${user.longitude}`}
+              coordinate={{ latitude: user.latitude, longitude: user.longitude }}
+              title={user.username}
+              onPress={() => handleMarkerPress(user)}
+            >
+              {user.image ? <Image source={{ uri: user.image }} style={styles.userImage} /> : null}
+            </Marker>
+          ))}
+        {mapReady && myLocation && gpsEnabled && (
+          <Marker
+            coordinate={{ latitude: myLocation.latitude, longitude: myLocation.longitude }}
+            title={`Mein Standort (${username})`}
           >
-            {mapReady &&
-              eventLocations.map((event, index) => (
-                <Marker
-                  key={index}
-                  coordinate={{ latitude: event.latitude, longitude: event.longitude }}
-                  onPress={() => handleMarkerPressEvent(event)}
-                >
-                  <View style={styles.markerContainer}>
-                    <Text style={styles.markerText}>{event.eventname}</Text>
-                    <Image source={{ uri: event.image }} style={styles.markerImage} />
-                  </View>
-                </Marker>
-              ))}
-            {mapReady &&
-              userLocations.map((user, index) => (
-                <Marker
-                  key={index}
-                  coordinate={{ latitude: user.latitude, longitude: user.longitude }}
-                  title={user.username}
-                  onPress={() => handleMarkerPress(user)}
-                >
-                  {user.image && <Image source={{ uri: user.image }} style={styles.userImage} />}
-                </Marker>
-              ))}
-            {mapReady && myLocation && gpsEnabled && (
-              <Marker
-                coordinate={{ latitude: myLocation.latitude, longitude: myLocation.longitude }}
-                title={`Mein Standort (${username})`}
-              >
-                <Image source={require('../assets/NadelGeojam.png')} style={styles.userImage} />
-              </Marker>
-            )}
-          </MapView>
-          <View style={styles.gpsToggleContainer}>
-            <Text style={styles.gpsToggleText}>GPS {gpsEnabled ? 'EIN' : 'AUS'}</Text>
-            <Switch value={gpsEnabled} onValueChange={handleToggleGPS} />
-          </View>
-        </>
-      )}
+            <Image source={require('../assets/NadelGeojam.png')} style={styles.userImage} />
+          </Marker>
+        )}
+      </MapView>
+      <View style={styles.gpsToggleContainer}>
+        <Text style={styles.gpsToggleText}>GPS {gpsEnabled ? 'EIN' : 'AUS'}</Text>
+        <Switch value={gpsEnabled} onValueChange={handleToggleGPS} />
+      </View>
+      <View style={styles.mapSummary}>
+        <Text style={styles.summaryText}>Events: {eventCount}</Text>
+        <Text style={styles.summaryText}>Freunde online: {activeUsers.length}</Text>
+      </View>
     </View>
   );
 };
 
 const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#000',
+  },
+  map: {
+    flex: 1,
+  },
   markerContainer: {
     alignItems: 'center',
   },
@@ -218,8 +251,8 @@ const styles = StyleSheet.create({
     height: 60,
   },
   userImage: {
-    width: 80,
-    height: 80,
+    width: 72,
+    height: 72,
   },
   gpsToggleContainer: {
     position: 'absolute',
@@ -236,6 +269,23 @@ const styles = StyleSheet.create({
     fontSize: 16,
     marginBottom: 5,
     color: '#fff',
+  },
+  mapSummary: {
+    position: 'absolute',
+    bottom: 32,
+    left: 20,
+    right: 20,
+    padding: 14,
+    borderRadius: 16,
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    backgroundColor: 'rgba(0, 0, 0, 0.7)',
+    borderWidth: 1,
+    borderColor: '#FF5C93',
+  },
+  summaryText: {
+    color: '#fff',
+    fontWeight: '600',
   },
 });
 

--- a/screens/PostScreen.js
+++ b/screens/PostScreen.js
@@ -1,22 +1,21 @@
-import React, { useState, useEffect } from 'react';
-import { View, Text, StyleSheet, Image, FlatList, TouchableOpacity, Alert, TextInput } from 'react-native';
-import { getAuth } from 'firebase/auth';
-import { getFirestore, collection, query, orderBy, onSnapshot, doc, updateDoc, getDoc, arrayUnion, arrayRemove, addDoc, serverTimestamp } from 'firebase/firestore';
+import React, { useEffect, useRef, useState } from 'react';
+import { View, Text, StyleSheet, Image, FlatList, TouchableOpacity, TextInput } from 'react-native';
+import { collection, query, orderBy, onSnapshot, doc, updateDoc, getDoc, arrayUnion, arrayRemove, addDoc, serverTimestamp } from 'firebase/firestore';
 import { AntDesign, FontAwesome } from '@expo/vector-icons';
-import app from '../components/firebase';
 import { useNavigation } from '@react-navigation/native';
 import { Video } from 'expo-av';
 import { useUser } from '../UserContext';
+import { auth, db } from '../components/firebase';
 import Comment from '../components/Comment';
 
 const PostScreen = () => {
   const [posts, setPosts] = useState([]);
   const [comments, setComments] = useState({});
   const [commentText, setCommentText] = useState('');
-  const auth = getAuth(app);
   const user = auth.currentUser;
   const navigation = useNavigation();
   const { user: contextUser } = useUser();
+  const commentUnsubscribersRef = useRef({});
 
   useEffect(() => {
     navigation.setOptions({
@@ -30,31 +29,50 @@ const PostScreen = () => {
       },
     });
 
-    const db = getFirestore(app);
-    const q = query(collection(db, 'posts'), orderBy('createdAt', 'desc'));
-    const unsubscribe = onSnapshot(q, (querySnapshot) => {
-      const newPosts = [];
-      querySnapshot.forEach((postDoc) => {
-        const data = postDoc.data();
-        newPosts.push({ id: postDoc.id, ...data });
+    const postsQuery = query(collection(db, 'posts'), orderBy('createdAt', 'desc'));
+    const unsubscribePosts = onSnapshot(postsQuery, (querySnapshot) => {
+      const nextPosts = querySnapshot.docs.map((postDoc) => ({ id: postDoc.id, ...postDoc.data() }));
+      setPosts(nextPosts);
 
-        const commentsQuery = query(collection(db, 'posts', postDoc.id, 'comments'), orderBy('createdAt', 'desc'));
-        onSnapshot(commentsQuery, (commentsSnapshot) => {
-          const postComments = [];
-          commentsSnapshot.forEach((commentDoc) => {
-            postComments.push({ id: commentDoc.id, ...commentDoc.data() });
+      const activePostIds = new Set(querySnapshot.docs.map((docSnapshot) => docSnapshot.id));
+
+      querySnapshot.docs.forEach((postDoc) => {
+        if (!commentUnsubscribersRef.current[postDoc.id]) {
+          const commentsQuery = query(
+            collection(db, 'posts', postDoc.id, 'comments'),
+            orderBy('createdAt', 'desc')
+          );
+          commentUnsubscribersRef.current[postDoc.id] = onSnapshot(commentsQuery, (commentsSnapshot) => {
+            const postComments = commentsSnapshot.docs.map((commentDoc) => ({
+              id: commentDoc.id,
+              ...commentDoc.data(),
+            }));
+            setComments((prevComments) => ({ ...prevComments, [postDoc.id]: postComments }));
           });
-          setComments(prevComments => ({ ...prevComments, [postDoc.id]: postComments }));
-        });
+        }
       });
-      setPosts(newPosts);
+
+      Object.keys(commentUnsubscribersRef.current).forEach((postId) => {
+        if (!activePostIds.has(postId)) {
+          commentUnsubscribersRef.current[postId]?.();
+          delete commentUnsubscribersRef.current[postId];
+          setComments((prevComments) => {
+            const next = { ...prevComments };
+            delete next[postId];
+            return next;
+          });
+        }
+      });
     });
 
-    return () => unsubscribe();
+    return () => {
+      unsubscribePosts();
+      Object.values(commentUnsubscribersRef.current).forEach((unsubscribe) => unsubscribe?.());
+      commentUnsubscribersRef.current = {};
+    };
   }, [navigation]);
 
   const handleLike = async (postId) => {
-    const db = getFirestore(app);
     const postRef = doc(db, 'posts', postId);
 
     const postDoc = await getDoc(postRef);
@@ -79,7 +97,6 @@ const PostScreen = () => {
   const handleAddComment = async (postId) => {
     if (commentText.trim() === '') return;
 
-    const db = getFirestore(app);
     const commentData = {
       text: commentText,
       username: contextUser.username,

--- a/screens/ProfileScreen.js
+++ b/screens/ProfileScreen.js
@@ -1,15 +1,14 @@
 import React, { useState, useEffect } from 'react';
 import { View, Text, StyleSheet, FlatList, Image, TouchableOpacity, TextInput, ScrollView, Dimensions, ActivityIndicator, Alert, StatusBar } from 'react-native';
-import { getFirestore, collection, query, where, onSnapshot, doc, updateDoc, orderBy } from 'firebase/firestore';
-import { getStorage, ref, uploadBytes, getDownloadURL } from 'firebase/storage';
+import { collection, query, where, onSnapshot, doc, updateDoc, orderBy } from 'firebase/firestore';
+import { ref, uploadBytes, getDownloadURL } from 'firebase/storage';
 import * as ImagePicker from 'expo-image-picker';
-import app from '../components/firebase';
 import { Video, ResizeMode } from 'expo-av';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import Ionicons from '@expo/vector-icons/Ionicons';
 import MaterialCommunityIcons from '@expo/vector-icons/MaterialCommunityIcons';
-import { getAuth } from 'firebase/auth';
 import { useNavigation } from '@react-navigation/native';
+import { app, auth, db, storage } from '../components/firebase';
 
 const { width } = Dimensions.get('window');
 
@@ -29,8 +28,6 @@ const ProfileScreen = ({ route }) => {
   const [posts, setPosts] = useState([]);
   const [isEditMode, setIsEditMode] = useState(false);
   const [selectedTab, setSelectedTab] = useState('videos');
-  const db = getFirestore(app);
-  const auth = getAuth(app);
   const currentUser = auth.currentUser;
 
   useEffect(() => {
@@ -99,7 +96,6 @@ const ProfileScreen = ({ route }) => {
     });
 
     if (!result.canceled) {
-      const storage = getStorage(app);
       const response = await fetch(result.assets[0].uri);
       const blob = await response.blob();
       const storageRef = ref(storage, `profile-pictures/${userId}`);

--- a/screens/UploadScreen.js
+++ b/screens/UploadScreen.js
@@ -1,12 +1,12 @@
 import React, { useState, useEffect } from 'react';
 import { View, Text, TextInput, StyleSheet, Image, TouchableOpacity, Alert } from 'react-native';
 import * as ImagePicker from 'expo-image-picker';
-import { getFirestore, collection, addDoc } from 'firebase/firestore';
+import { collection, addDoc } from 'firebase/firestore';
 import { useNavigation } from '@react-navigation/native';
-import { getStorage, ref, uploadBytes, getDownloadURL } from 'firebase/storage';
+import { ref, uploadBytes, getDownloadURL } from 'firebase/storage';
 import { Video } from 'expo-av';
-import app from '../components/firebase';
 import { useUser } from '../UserContext';
+import { db, storage } from '../components/firebase';
 
 const UploadScreen = () => {
   const [postText, setPostText] = useState('');
@@ -37,9 +37,6 @@ const UploadScreen = () => {
       Alert.alert('Error', 'Please add some text or an image/video.');
       return;
     }
-
-    const db = getFirestore(app);
-    const storage = getStorage(app);
 
     let mediaUrl = null;
     if (media) {


### PR DESCRIPTION
## Summary
- add a Discover tab with event filtering, trending posts, and reusable event/product cards
- centralize Firestore subscriptions through a reusable hook and apply it across the shop, map, and post flows
- refresh map navigation, event shop balance handling, and post/comment listeners for better realtime behaviour

## Testing
- not run (project has no automated test suite)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6918c4f6d8fc8322a95f6288d8ff6444)